### PR TITLE
add assertion

### DIFF
--- a/src/main/java/sigmabot/ui/commands/AddTaskCommand.java
+++ b/src/main/java/sigmabot/ui/commands/AddTaskCommand.java
@@ -54,7 +54,8 @@ public final class AddTaskCommand extends Command {
         } else if (input.startsWith("todo")) {
             this.task = new ToDo(description);
         } else {
-            throw new UnknownCommandInputException(input);
+            this.task = null;
+            assert false : "The check for validity of the task type must've been performed earlier";
         }
     }
 


### PR DESCRIPTION
There's a double check for accordance of the task type.

One of the checks must not be executed.

Perform assertion within the AddTaskCommand class, as it's guaranteed that the task already has an appropriate type.

Assertion is used as reaching this line clearly indicates inconsistency in code and in logic.